### PR TITLE
use ipv6 notation as WebApi URL

### DIFF
--- a/WebApi.NetCore/Program.cs
+++ b/WebApi.NetCore/Program.cs
@@ -20,6 +20,7 @@ namespace WebApi.NetCore
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .Build();
+				.UseUrls("http://[::]:5000")
+				.Build();
     }
 }


### PR DESCRIPTION
somehow Docker wants the given URLs in .UseUrls in IPv6 notation...